### PR TITLE
Fixed MULTIMON_STUB stuff breaking <VS2010

### DIFF
--- a/winplace.cpp
+++ b/winplace.cpp
@@ -13,7 +13,13 @@
 static char BASED_CODE THIS_FILE[] = __FILE__;
 #endif
 
+// Version 10 of the MFC framework removed functions we need.
+// Which means we need to force generation of stubs in that case.
+// See: http://cppdepend.wordpress.com/2010/08/29/visual-c-2010-what’s-new-for-mfc-library/
+#if _MFC_VER >= 0x0A00
 #define COMPILE_MULTIMON_STUBS
+#endif
+
 #include <MULTIMON.H>
 
 CWindowPlacement::CWindowPlacement()


### PR DESCRIPTION
Or well, it should be fixed, as I cannot test it. The check is on the version of the MFC framework, as opposed to the version of the compiler. Hope that's good enough. :)

In case you are interested, reason it broke in VS2010 is listed at the end of this article: http://cppdepend.wordpress.com/2010/08/29/visual-c-2010-what’s-new-for-mfc-library/
