### PR TITLE
document the triggered line in error messages

### DIFF
--- a/doc.cpp
+++ b/doc.cpp
@@ -2622,8 +2622,8 @@ void CMUSHclientDoc::ExecuteTriggerScript (CTrigger * trigger_item,
      return;
 
   CString strType = "trigger";
-  CString strReason =  TFormat ("processing trigger \"%s\"", 
-                            (LPCTSTR) trigger_item->strLabel);
+  CString strReason =  TFormat ("processing trigger \"%s\" on line \"%s\"", 
+                            (LPCTSTR) trigger_item->strLabel, (LPCTSTR) strCurrentLine);
 
   // get unlabelled trigger's internal name
   const char * pLabel = trigger_item->strLabel;


### PR DESCRIPTION
The triggered line is critical information when determining failure root cause.
(I haven't actually tested this (testing requires the Windows VM compilation rigamarole) but it seems simple enough.)