### PR TITLE
without empty styles, we never catch colored EOLs

### DIFF
--- a/paneline.cpp
+++ b/paneline.cpp
@@ -13,9 +13,12 @@
 // adds text to a line, adds to current style run if possible
 void CPaneLine::AddStyle (const CPaneStyle style)
     {
-    // don't need to if no text in style  (maybe)
-    if (style.m_sText.empty ())
-      return;
+    // This comment used to say that we didn't need to preserve textless colors, 
+    // but it impacts the accurate preservation of data because servers may send
+    // color changes just before newlines which _should_ bleed over, but then don't. 
+    // - Fiendish
+    //if (style.m_sText.empty ())
+    //  return;
 
     // if first style for line, must be a new style
     if (m_vStyles.empty ())


### PR DESCRIPTION
This fixes a problem I'm having with being unable to capture style runs that are supposed to bleed across lines.

See https://mushclient.com/forum/?id=13892&reply=3#reply3