### PR TITLE
make new versions easier

### DIFF
--- a/MUSHclient.cpp
+++ b/MUSHclient.cpp
@@ -235,7 +235,7 @@ BOOL CMUSHclientApp::InitInstance()
 
   MUSHCLIENT_VERSION = VERSION_STRING;
 
-#if _MSC_VER == 1900     // 1200 for Visual Studio 6, 1900 for MSVC 2015
+#ifdef PRE_RELEASE
   MUSHCLIENT_VERSION += "-pre";
 #endif
 

--- a/MUSHclient.cpp
+++ b/MUSHclient.cpp
@@ -233,7 +233,7 @@ BOOL CMUSHclientApp::InitInstance()
 
   char fullfilename [MAX_PATH];
 
-  MUSHCLIENT_VERSION = MUSHCLIENT_BASE_VERSION;
+  MUSHCLIENT_VERSION = VERSION_STRING;
 
 #if _MSC_VER == 1900     // 1200 for Visual Studio 6, 1900 for MSVC 2015
   MUSHCLIENT_VERSION += "-pre";
@@ -843,7 +843,7 @@ BOOL CMUSHclientApp::InitInstance()
 
     version = db_get_int ("control", "Version", 0);	
 
-    if (version < THISVERSION)  // THISVERSION is defined at start of this module
+    if (version < THISVERSION)  // THISVERSION is defined in version.h
       {
 
       CWelcome1Dlg dlg;         // Welcome to this version dialog

--- a/MUSHclient.rc
+++ b/MUSHclient.rc
@@ -1,6 +1,7 @@
 //Microsoft Developer Studio generated resource script.
 //
 #include "resource.h"
+#include "version.h"
 
 #define APSTUDIO_READONLY_SYMBOLS
 /////////////////////////////////////////////////////////////////////////////
@@ -75,8 +76,8 @@ END
 //
 
 VS_VERSION_INFO VERSIONINFO
- FILEVERSION 5,0,5,0
- PRODUCTVERSION 5,0,5,0
+ FILEVERSION VERSION_16WORDS
+ PRODUCTVERSION VERSION_16WORDS
  FILEFLAGSMASK 0x3fL
 #ifdef _DEBUG
  FILEFLAGS 0x1L
@@ -94,14 +95,14 @@ BEGIN
             VALUE "Comments", "MUSHclient - a client program for playing MUD games\0"
             VALUE "CompanyName", "Nick Gammon\0"
             VALUE "FileDescription", "MUSHclient\0"
-            VALUE "FileVersion", "5.05\0"
+            VALUE "FileVersion", VERSION_STRING
             VALUE "InternalName", "MUSHCLIENT\0"
             VALUE "LegalCopyright", "Copyright © 2016 Nick Gammon\0"
             VALUE "LegalTrademarks", "\0"
             VALUE "OriginalFilename", "MUSHCLIENT.EXE\0"
             VALUE "PrivateBuild", "\0"
             VALUE "ProductName", "MUSHclient\0"
-            VALUE "ProductVersion", "5.05\0"
+            VALUE "ProductVersion", VERSION_STRING
             VALUE "SpecialBuild", "\0"
         END
     END

--- a/MUSHclient.vcxproj
+++ b/MUSHclient.vcxproj
@@ -177,7 +177,7 @@
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
-    <ClCompile Include="CHATSOCK.CPP">
+    <ClCompile Include="chatsock.cpp">
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
@@ -1429,6 +1429,7 @@
     <ClInclude Include="luacom\tLuaVector.h" />
     <ClInclude Include="luacom\tStringBuffer.h" />
     <ClInclude Include="luacom\tUtil.h" />
+    <ClInclude Include="version.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="res\cursor1.cur" />

--- a/MUSHclient.vcxproj
+++ b/MUSHclient.vcxproj
@@ -122,7 +122,7 @@
       <Optimization>MaxSpeed</Optimization>
       <InlineFunctionExpansion>OnlyExplicitInline</InlineFunctionExpansion>
       <AdditionalIncludeDirectories>$(SolutionDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PreprocessorDefinitions>NDEBUG;WIN32;_WINDOWS;ZLIB_DLL;LUA51;_CRT_SECURE_NO_WARNINGS;_CRT_NON_CONFORMING_SWPRINTFS;NO_WARN_MBCS_MFC_DEPRECATION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;WIN32;_WINDOWS;ZLIB_DLL;LUA51;_CRT_SECURE_NO_WARNINGS;_CRT_NON_CONFORMING_SWPRINTFS;NO_WARN_MBCS_MFC_DEPRECATION;$(PRE_RELEASE);%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <StringPooling>true</StringPooling>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FunctionLevelLinking>true</FunctionLevelLinking>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,6 +4,10 @@ branches:
   - master
 skip_tags: true
 configuration: Release
+environment:
+  auth_token:
+    secure: SKQr480MzNJLzmyrFxDeMta2nHica+9ed2n1Djpa53ioURK0NLo/iStu9DhUrQIK
+  PRE_RELEASE: PRE_RELEASE
 build:
   project: MUSHclient_2015.sln
   parallel: true
@@ -11,9 +15,6 @@ build:
 artifacts:
 - path: WinRel\MUSHclient.exe
   name: release_exe
-environment:
-  auth_token:
-    secure: SKQr480MzNJLzmyrFxDeMta2nHica+9ed2n1Djpa53ioURK0NLo/iStu9DhUrQIK
 before_deploy:
 - git config --global credential.helper store
 - ps: Add-Content "$env:USERPROFILE\.git-credentials" "https://$($env:auth_token):x-oauth-basic@github.com`n"

--- a/doc.h
+++ b/doc.h
@@ -14,20 +14,10 @@
 #include "paneline.h"
 #include "miniwindow.h"
 #include "plugins.h"
+#include "version.h"
 
 #define COMPRESS_BUFFER_LENGTH 1024   // size of decompression buffer
-
-// ============================================================================
-
-// New versions - things to change
-
-#define THISVERSION 505                           // Step 1.
-const CString MUSHCLIENT_BASE_VERSION = "5.05";   // Step 2.
-
-extern CString MUSHCLIENT_VERSION;    // will have "-pre" appended by automatic builds
-
-// Step 3. Don't forget VERSION resource in Resources tab
-// Step 4. Remember: README.TXT 
+extern CString MUSHCLIENT_VERSION;
 
 // ============================================================================
 

--- a/version.h
+++ b/version.h
@@ -1,0 +1,6 @@
+#define THISVERSION 505
+#define VERSION_16WORDS 5,0,5,0
+#define VERSION_STRING "5.05"
+
+// remember README
+


### PR DESCRIPTION
Version info should only be in one spot
Also forward an environment variable defined in the appveyor file to check instead of looking at the version of the compiler. Otherwise you can't update your compiler ever.