### PR TITLE
never clobber specified mode/flags or position

### DIFF
--- a/lua/movewindow.lua
+++ b/lua/movewindow.lua
@@ -271,7 +271,6 @@ local function make_check_map_position_handler (mwi)
          mwi.window_left > GetInfo (281) - mwi.margin or
          mwi.window_top < 0 or -- don't drag title out of view
          mwi.window_top > GetInfo (280) - mwi.margin then
-           mwi.window_left, mwi.window_top = 0, 0  -- reset to center right
            mwi.window_mode = miniwin.pos_center_right
            mwi.window_flags = 0
       end -- if not visible
@@ -305,8 +304,8 @@ function movewindow.install (win, default_position, default_flags, nocheck, frie
      -- save current position in table (obtained from state file)
      window_left  = tonumber (GetVariable ("mw_" .. win .. "_windowx")) or (start_position and start_position.x) or 0,
      window_top   = tonumber (GetVariable ("mw_" .. win .. "_windowy")) or (start_position and start_position.y) or 0,     
-     window_mode  = tonumber (GetVariable ("mw_" .. win .. "_windowmode")) or default_position,
-     window_flags = tonumber (GetVariable ("mw_" .. win .. "_windowflags")) or default_flags,
+     window_mode  = default_position,
+     window_flags = default_flags,
      window_friends = friends or {},
      window_friend_deltas = {},
      margin = 20,  -- how close we can put to the edge of the window
@@ -392,20 +391,18 @@ function movewindow.save_state (win)
     return
   end -- no such window
   
-  -- remember where the window was 
+  -- remember where the window was
+
+  -- use actual last specified position, not where we happen to think it is, in case another plugin moves it
+  -- suggested by Fiendish, 27 August 2012.
+  if WindowInfo (win, 1) then
+    mwi.window_left = WindowInfo(win, 1)
+  end
+  if WindowInfo (win, 2) then
+    mwi.window_top = WindowInfo(win, 2)
+  end
+
   SetVariable ("mw_" .. win .. "_windowx",      mwi.window_left)
   SetVariable ("mw_" .. win .. "_windowy",      mwi.window_top)
-  SetVariable ("mw_" .. win .. "_windowmode",   mwi.window_mode)
-  SetVariable ("mw_" .. win .. "_windowflags",  mwi.window_flags)
-  
-  -- use actual position, not where we happen to think it is, in case another plugin moves it
-  -- suggested by Fiendish, 27 August 2012.
-  if WindowInfo (win, 10) then
-    SetVariable ("mw_" .. win .. "_windowx",    WindowInfo(win, 10))
-  end
-  if WindowInfo (win, 11) then
-    SetVariable ("mw_" .. win .. "_windowy",    WindowInfo(win, 11))
-  end
-  
 
-end -- movewindow.save_state  
+end -- movewindow.save_state


### PR DESCRIPTION
This can cause problems when alternating between windows/displays of different sizes. If a user switches from a large window to a small one, the miniwindows may auto-position themselves at launch to keep them on screen. But when the user goes back to a large screen, they should get their original positions back, not be forced into their auto-position setting. Likewise, save specified location instead of auto location.