### PR TITLE
make SetClipboard follow the utf8 setting too

### DIFF
--- a/scripting/methods/methods_clipboard.cpp
+++ b/scripting/methods/methods_clipboard.cpp
@@ -25,5 +25,5 @@ CString strContents;
 
 void CMUSHclientDoc::SetClipboard(LPCTSTR Text) 
 {
-putontoclipboard (Text);
+putontoclipboard (Text, m_bUTF_8);
 }  // end of CMUSHclientDoc::SetClipboard


### PR DESCRIPTION
This is the minimum change needed for the CopyColourCodes plugin to be able to get utf8 lines