### PR TITLE
 keep_pause_at_bottom numeric option

### DIFF
--- a/doc.h
+++ b/doc.h
@@ -738,7 +738,8 @@ public:
 	unsigned short  m_bShowBold;   // show bold, italic, underline in fonts
 	unsigned short  m_bAltArrowRecallsPartial;     // alt+up arrow recalls partially entered command
   unsigned short  m_iPixelOffset;     // pixel offset of text from side of window
-  unsigned short  m_bAutoFreeze;    // freeze if not at bottom of buffer  
+  unsigned short  m_bAutoFreeze;    // freeze if not at bottom of buffer 
+  unsigned short  m_bKeepFreezeAtBottom; // don't automatically unfreeze after returning to bottom of buffer
   unsigned short  m_bAutoRepeat;    // auto repeat last command 
   unsigned short  m_bDisableCompression;      // don't allow compressed worlds
   unsigned short  m_bLowerCaseTabCompletion;  // tab complete words in lower case    

--- a/mushview.cpp
+++ b/mushview.cpp
@@ -4748,8 +4748,13 @@ int iDeltaY = m_scroll_position.y - pt.y;
 //  ScrollInfo.nPos = pt.x;
 //  SetScrollInfo (SB_HORZ, &ScrollInfo, pDoc->m_bScrollBarWanted);
   
-  if (pDoc->m_bAutoFreeze)
-    m_freeze = pt.y < (m_ScrollbarSizeTotal.cy - m_ScrollbarSizePage.cy);
+  if (pDoc->m_bAutoFreeze) {
+    if (pDoc->m_bKeepFreezeAtBottom) {
+      m_freeze = m_freeze || (pt.y < (m_ScrollbarSizeTotal.cy - m_ScrollbarSizePage.cy));
+    } else {
+      m_freeze = pt.y < (m_ScrollbarSizeTotal.cy - m_ScrollbarSizePage.cy);
+    }
+  }
 
   } // end of CMUSHView::ScrollToPosition
 

--- a/scriptingoptions.cpp
+++ b/scriptingoptions.cpp
@@ -51,6 +51,7 @@ tConfigurationNumericOption OptionsTable [] = {
 {"auto_allow_snooping",                 false, O(m_bAutoAllowSnooping)},                       
 {"auto_copy_to_clipboard_in_html",      false, O(m_bAutoCopyInHTML)},                       
 {"auto_pause",                          true,  O(m_bAutoFreeze)},                       
+{"keep_pause_at_bottom",                false, O(m_bKeepFreezeAtBottom)},
 {"auto_repeat",                         false, O(m_bAutoRepeat)}, 
 {"auto_resize_command_window",          false, O(m_bAutoResizeCommandWindow)},                      
 {"auto_resize_minimum_lines",           1,     O(m_iAutoResizeMinimumLines), 1, 100},    


### PR DESCRIPTION
In response to forum thread http://mushclient.com/forum/bbshowpost.php?id=14343

Use with `SetOption("keep_pause_at_bottom", 1)`