### PR TITLE
ANSI 24-bit color support

### DIFF
--- a/doc.cpp
+++ b/doc.cpp
@@ -1997,10 +1997,18 @@ CString strLine (lpszText, size);
         case HAVE_ESC:            Phase_ESC (c); continue;
         case HAVE_UTF8_CHARACTER: Phase_UTF8 (c); continue;
 
-        case HAVE_FOREGROUND_256_START:    // these 4 are similar to Phase_ANSI
+        case HAVE_FOREGROUND_256_START:    // these 12 are similar to Phase_ANSI
         case HAVE_FOREGROUND_256_FINISH:
         case HAVE_BACKGROUND_256_START:
         case HAVE_BACKGROUND_256_FINISH:
+        case HAVE_FOREGROUND_24B_FINISH:
+        case HAVE_FOREGROUND_24BR_FINISH:
+        case HAVE_FOREGROUND_24BG_FINISH:
+        case HAVE_FOREGROUND_24BB_FINISH:
+        case HAVE_BACKGROUND_24B_FINISH:
+        case HAVE_BACKGROUND_24BR_FINISH:
+        case HAVE_BACKGROUND_24BG_FINISH:
+        case HAVE_BACKGROUND_24BB_FINISH:
         case DOING_CODE:          
           Phase_ANSI (c); continue;
 

--- a/doc.h
+++ b/doc.h
@@ -86,8 +86,16 @@ enum { NONE,          // normal text
        HAVE_COMPRESS_WILL, // received TELNET IAC COMPRESS WILL
        HAVE_FOREGROUND_256_START,   // received ESC[38;
        HAVE_FOREGROUND_256_FINISH,  // received ESC[38;5;
+       HAVE_FOREGROUND_24B_FINISH,  // received ESC[38;2;
+       HAVE_FOREGROUND_24BR_FINISH,  // received ESC[38;2;nnn;
+       HAVE_FOREGROUND_24BG_FINISH,  // received ESC[38;2;nnn;nnn;
+       HAVE_FOREGROUND_24BB_FINISH,  // received ESC[38;2;nnn;nnn;nnn
        HAVE_BACKGROUND_256_START,   // received ESC[48;
        HAVE_BACKGROUND_256_FINISH,  // received ESC[48;5;
+       HAVE_BACKGROUND_24B_FINISH,
+       HAVE_BACKGROUND_24BR_FINISH,
+       HAVE_BACKGROUND_24BG_FINISH,
+       HAVE_BACKGROUND_24BB_FINISH,
 
        // utf-8 modes
        HAVE_UTF8_CHARACTER,         // received 110 xxxxx, 1110 xxxx, or 11110 xxx


### PR DESCRIPTION
This is an implementation of 24-bit color ANSI escape sequences (`38/48;2`). The primary functionality is built into `CMUSHclientDoc::Interpret256ANSIcode` (escape code `38/48;5`) due to the similarity in handling.

**See:** [Forum Thread](http://www.gammon.com.au/forum/?id=14381)

Comment for cleanup if necessary, though I did try to keep the commit as trim as possible.

**Please inspect** for any issues I may not be aware of, as I am not familiar with the entirety of the codebase.

Regards,

zinmirai