### PR TITLE
Use SetScrollPos not SetScrollInfo to prevent flickering during scroll

### DIFF
--- a/mushview.cpp
+++ b/mushview.cpp
@@ -4743,10 +4743,8 @@ int iDeltaY = m_scroll_position.y - pt.y;
   m_scroll_position = pt;
 
   // update scroll bar
-  GetScrollInfo (SB_VERT, &ScrollInfo, SIF_POS | SIF_ALL);
-  ScrollInfo.nPos = pt.y;
-  SetScrollInfo (SB_VERT, &ScrollInfo, pDoc->m_bScrollBarWanted);
-  m_ScrollbarPosition = ScrollInfo.nPos;
+  SetScrollPos (SB_VERT, pt.y, pDoc->m_bScrollBarWanted);
+  m_ScrollbarPosition = pt.y;
 
 
 //  GetScrollInfo (SB_HORZ, &ScrollInfo, SIF_POS);


### PR DESCRIPTION
I don't know why SetScrollInfo doesn't work right, but without this change, hiding the scroll bar and then scrolling causes the bar to flicker repeatedly, which causes the world to resize repeatedly for no reason, which causes OnPluginWorldOutputResized to get called repeatedly for no reason.

http://mushclient.com/forum/bbshowpost.php?bbsubject_id=14581&page=1