### PR TITLE
changed `endl` to `'\n'` for less latency

### DIFF
--- a/doc.h
+++ b/doc.h
@@ -2900,7 +2900,7 @@ class timer
       QueryPerformanceFrequency (&large_int_frequency);
       iCounterFrequency = large_int_frequency.QuadPart;
       QueryPerformanceCounter (&start);
-      TRACE (MAKE_STRING ("Start     : " << left << sReason << endl).c_str ());
+      TRACE (MAKE_STRING ("Start     : " << left << sReason << '\n').c_str ());
       };
 
     // destructor gets current time, displays difference
@@ -2916,7 +2916,7 @@ class timer
       // TRACE or ::AfxMessageBox (for release builds)
 
       TRACE (MAKE_STRING ( "Time taken: " << left << sReason << " = "
-           << fixed << fTime << " seconds." << endl ).c_str ());
+           << fixed << fTime << " seconds." << '\n' ).c_str ());
 
       }
   };    // end of class timer


### PR DESCRIPTION
Replaced `std::endl` with `'\n'`. `std::endl` includes `std::flush`, which is unnecessary in this context and slows things down. So, it was replaced with `'\n'` which is faster and provides more accurate benchmarks.