### PR TITLE
Terminate the trigger match trace output

### DIFF
--- a/ProcessPreviousLine.cpp
+++ b/ProcessPreviousLine.cpp
@@ -1108,9 +1108,9 @@ POSITION pos;
          putontoclipboard (trigger_item->wildcards [trigger_item->iClipboardArg].c_str (), m_bUTF_8);
 
       if (trigger_item->strLabel.IsEmpty ())
-        Trace ("Matched trigger \"%s\"", (LPCTSTR) trigger_item->trigger);
+        Trace ("Matched trigger \"%s\"\n", (LPCTSTR) trigger_item->trigger);
       else
-        Trace ("Matched trigger %s", (LPCTSTR) trigger_item->strLabel);
+        Trace ("Matched trigger %s\n", (LPCTSTR) trigger_item->strLabel);
 
     // play the trigger sound, if we matched on a trigger
 


### PR DESCRIPTION
Trigger matches currently don't terminate the display line, which means another trace will go on the same line.

> TRACE: Matched trigger "^### \(.+$"TRACE: Executing Plugin Aardwolf_Main_Layout script "OnPluginScreendraw"