### PR TITLE
Force trace messages to end in newline

### DIFF
--- a/scripting/methods/methods_tracing.cpp
+++ b/scripting/methods/methods_tracing.cpp
@@ -49,6 +49,10 @@ CString strFullMsg = "TRACE: ";
 
   strFullMsg += strMsg;
 
+  if (strMsg.Right(1) != "\n") {
+      strFullMsg += "\n"
+  }
+
 
   DisplayMsg (strFullMsg, strFullMsg.GetLength (), COMMENT);
 


### PR DESCRIPTION
I think all traces should end in a newline, and forcing it is easier than editing every invocation.
Otherwise we end up with stacked traces like this:

> TRACE: Matched trigger "^### \(.+$"TRACE: Executing Plugin Aardwolf_Main_Layout script "OnPluginScreendraw"