### PR TITLE
Fix bug where selection sometimes jumps backwards

### DIFF
--- a/mushview.cpp
+++ b/mushview.cpp
@@ -1930,7 +1930,7 @@ long pixel;
   // don't stop half-way through a UTF-8 character
   if (pDoc->m_bUTF_8)
     while (col && (pLine->text [col] & 0xC0) == 0x80)
-      col--;
+      col++;
 
 // if we are 50% through this character, take the next one, otherwise take the previous one
 


### PR DESCRIPTION
Sometimes the selection jumps backwards and then makes it impossible to select the last character in a line unless you move the selection to the next line.
Had this reported by a bunch of people. Finally looked into it.
![Screen Recording 2020-08-21 at 9 49 40 PM](https://user-images.githubusercontent.com/201996/90951414-04da8800-e418-11ea-9369-f6b4cd99cf71.gif)

It only happens when UTF8 is active. 
The weird part to me is that it's not predictable which lines it will happen on, but once it happens on a line it always happens on that same line (but not necessarily the same text printed again). But I added some tracing output and noticed that it happened only when that `col--` was called, and this change appears to fix it.