### PR TITLE
Proposed fix for addhotspot error while dragging

### DIFF
--- a/scripting/methods/methods_miniwindows.cpp
+++ b/scripting/methods/methods_miniwindows.cpp
@@ -577,7 +577,7 @@ static bool bInWindowAddHotspot = false;
                            Flags);
 
   // in mouse was over hotspot when it was created, do a "mouse move" to detect this
-  if (status == eOK)
+  if ((status == eOK) && !(GetCapture()))
     {
 
     // only check the current hotspot, not all of them


### PR DESCRIPTION
It seems like this mousemove check for newly created hotspots shouldn't happen if the user is already dragging another hotspot around.