### PR TITLE
Re-add dialog focus, just without selection

### DIFF
--- a/dialogs/plugins/PluginsDlg.cpp
+++ b/dialogs/plugins/PluginsDlg.cpp
@@ -205,6 +205,9 @@ int nItem = 0;
 
   m_ctlPluginList.SortItems (CompareFunc, m_reverse << 8 | m_last_col); 
 
+  // focus on the list but don't select anything
+  m_ctlPluginList.SetItemState (0, LVIS_FOCUSED, LVIS_FOCUSED);
+
   } // end of CPluginsDlg::LoadList
 
 void CPluginsDlg::OnColumnclickPluginsList(NMHDR* pNMHDR, LRESULT* pResult) 


### PR DESCRIPTION
Wine and Windows behavior diverges here slightly. In Wine items in the plugin dialog can be selected by first letter without this change, but in Windows apparently that is not the case. We still don't want to select anything though to prevent double removals like the previous edit here.