### PR TITLE
Allow `make()` to pass arbitrary arguments to coroutines

### DIFF
--- a/lua/wait.lua
+++ b/lua/wait.lua
@@ -154,7 +154,7 @@ end -- function match
 -- ----------------------------------------------------------
 -- wait.make: makes a coroutine and resumes it
 -- ----------------------------------------------------------
-function make (f)
+function make (f, ...)
   assert (type (f) == "function", "wait.make requires a function")
   
   -- More friendly failure, suggested by Fiendish
@@ -175,6 +175,6 @@ function make (f)
                 "Please check your configuration settings.")
     return nil, "Trigger/Timers not enabled"  -- bad return
   end  -- if have errors
-  coroutine.wrap (f) () -- make coroutine, resume it
+  coroutine.wrap (f) (...) -- make coroutine, resume it
   return true  -- good return
 end -- make


### PR DESCRIPTION
#### Why the Change

I often find myself (and see others) writing plugin functions similar to the following somewhat simplified example:

```
function countdown_alias(name, line, wildcards)
    local count = tonumber(wildcards.count) or 3
    wait.make(function()
        while count >= 0 do
            Note(count)
            wait.time(1)
            count = count - 1
        end
    end)
end
```

This is currently the best way to use `wait.make()` for such a need, but there are some problems:

- The `countdown_alias()` function contains too many levels of indentation and is arguably harder to read than needs be for such a simple case.
- The coroutine that actually does the counting down is anonymous and therefore not reusable anywhere else in the script.
- The coroutine also depends on the `count` upvalue, so it can't be factored out into a named function without making `count` a global variable.

#### Solution

Modify `make()`'s signature to accept a variable number of arguments, and pass those arguments on to the coroutine it makes. This enables plugin authors to write more generic, reusable coroutines that don't necessarily depend on upvalues or global variables, resulting in cleaner and more maintainable code like this:

```
local function countdown(count)
    while count >= 0 do
        Note(count)
        wait.time(1)
        count = count - 1
    end
end


function countdown_alias(name, line, wildcards)
    local count = tonumber(wildcards.count) or 3
    wait.make(countdown, count)
end
```

The coroutine can now be written to accept any arbitrary input, and it will receive it from `make()`. I've also tested and confirmed that this should not break any existing code that uses `make()`, as anything beyond the first param is optional.