### PR TITLE
De-collide workflow runs

### DIFF
--- a/.github/workflows/latest-dev-build.yml
+++ b/.github/workflows/latest-dev-build.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   SOLUTION_FILE_PATH: MUSHclient_2022.sln
   BUILD_CONFIGURATION_RELEASE: Release


### PR DESCRIPTION
I think this does it?
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs#example-only-cancel-in-progress-jobs-or-runs-for-the-current-workflow
